### PR TITLE
Add background mode voip and audio in project settings

### DIFF
--- a/Antidote.xcodeproj/project.pbxproj
+++ b/Antidote.xcodeproj/project.pbxproj
@@ -787,6 +787,15 @@
 			attributes = {
 				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = dvor;
+				TargetAttributes = {
+					1164762E19794D3300DB20B8 = {
+						SystemCapabilities = {
+							com.apple.BackgroundModes = {
+								enabled = 1;
+							};
+						};
+					};
+				};
 			};
 			buildConfigurationList = 1164762A19794D3300DB20B8 /* Build configuration list for PBXProject "Antidote" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/Antidote/Antidote-Info.plist
+++ b/Antidote/Antidote-Info.plist
@@ -37,6 +37,11 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+		<string>voip</string>
+	</array>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
Haven't really tested this yet if this keeps the call alive in the background. But this is needed if we later decide to keep a connection to toxav for incoming calls.