### PR TITLE
Switch from tox.me to tox.chat in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://img.shields.io/travis/Antidote-for-Tox/Antidote/master.svg?style=flat)](https://travis-ci.org/Antidote-for-Tox/Antidote)
 
-[Tox](https://tox.im/) client for iOS 7.0+;
+[Tox](https://tox.chat/) client for iOS 7.0+;
 
 ## Screenshots
 


### PR DESCRIPTION
Reason: https://blog.tox.chat/2015/07/current-situation-3/