### PR TITLE
Refactor of ActiveCallsViewController

### DIFF
--- a/Antidote.xcodeproj/project.pbxproj
+++ b/Antidote.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		F09B9A281B45AF3800F74A46 /* RingingCallViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F09B9A271B45AF3800F74A46 /* RingingCallViewController.m */; };
 		F09B9A2B1B45AF4300F74A46 /* ActiveCallViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F09B9A2A1B45AF4300F74A46 /* ActiveCallViewController.m */; };
 		F09B9A2E1B45B26600F74A46 /* AbstractCallViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F09B9A2D1B45B26600F74A46 /* AbstractCallViewController.m */; };
+		F0A37E391B6758610099B225 /* CallControlsView.m in Sources */ = {isa = PBXBuildFile; fileRef = F0A37E381B6758610099B225 /* CallControlsView.m */; };
 		F0B6BEA71B603C2000A54B25 /* RingTonePlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = F0B6BEA61B603C2000A54B25 /* RingTonePlayer.m */; };
 		F0B6BEAA1B60472900A54B25 /* ringtone.wav in Resources */ = {isa = PBXBuildFile; fileRef = F0B6BEA91B60472900A54B25 /* ringtone.wav */; };
 		F0D127DD1B445B2700E2E7B8 /* DialingCallViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F0D127DC1B445B2700E2E7B8 /* DialingCallViewController.m */; };
@@ -229,6 +230,8 @@
 		F09B9A2A1B45AF4300F74A46 /* ActiveCallViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ActiveCallViewController.m; sourceTree = "<group>"; };
 		F09B9A2C1B45B26600F74A46 /* AbstractCallViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AbstractCallViewController.h; sourceTree = "<group>"; };
 		F09B9A2D1B45B26600F74A46 /* AbstractCallViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AbstractCallViewController.m; sourceTree = "<group>"; };
+		F0A37E371B6758610099B225 /* CallControlsView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CallControlsView.h; sourceTree = "<group>"; };
+		F0A37E381B6758610099B225 /* CallControlsView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CallControlsView.m; sourceTree = "<group>"; };
 		F0B6BEA51B603C2000A54B25 /* RingTonePlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RingTonePlayer.h; sourceTree = "<group>"; };
 		F0B6BEA61B603C2000A54B25 /* RingTonePlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RingTonePlayer.m; sourceTree = "<group>"; };
 		F0B6BEA91B60472900A54B25 /* ringtone.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = ringtone.wav; sourceTree = "<group>"; };
@@ -745,6 +748,8 @@
 				F09B9A2D1B45B26600F74A46 /* AbstractCallViewController.m */,
 				F066F7D41B5F56B3002B2ADF /* IncomingCallNotificationView.h */,
 				F066F7D51B5F56B3002B2ADF /* IncomingCallNotificationView.m */,
+				F0A37E371B6758610099B225 /* CallControlsView.h */,
+				F0A37E381B6758610099B225 /* CallControlsView.m */,
 			);
 			name = Call;
 			sourceTree = "<group>";
@@ -1055,6 +1060,7 @@
 				118352A8197A64B70048CA64 /* SettingsViewController.m in Sources */,
 				119BB11E198B536300380557 /* AppDelegate+Utilities.m in Sources */,
 				F09B9A2B1B45AF4300F74A46 /* ActiveCallViewController.m in Sources */,
+				F0A37E391B6758610099B225 /* CallControlsView.m in Sources */,
 				F0B6BEA71B603C2000A54B25 /* RingTonePlayer.m in Sources */,
 				119DFAD11B3EA462008CA975 /* NotificationObject.m in Sources */,
 				11CFD0BD1B401394002C59DB /* WindowPassingGestures.m in Sources */,

--- a/Antidote/ActiveCallViewController.h
+++ b/Antidote/ActiveCallViewController.h
@@ -64,14 +64,9 @@
 @property (assign, nonatomic) BOOL speakerSelected;
 
 /**
- * Show the resume button so the user can resume a paused call.
+ * Set whether or not the resume button is hidden.
  */
-- (void)showResumeButton;
-
-/**
- * Hide the resume button.
- */
-- (void)hideResumeButton;
+@property (assign, nonatomic) BOOL resumeButtonHidden;
 
 /**
  * Create an incoming call view for friend

--- a/Antidote/ActiveCallViewController.m
+++ b/Antidote/ActiveCallViewController.m
@@ -51,8 +51,7 @@ static const CGFloat kBadgeFontSize = 14.0;
 
 @property (strong, nonatomic) NSTimer *tableViewRefreshTimer;
 
-@property (strong, nonatomic) MASConstraint *videoCenterXConstraint;
-@property (strong, nonatomic) MASConstraint *videoRightConstraint;
+@property (strong, nonatomic) MASConstraint *videoHorizontalConstraint;
 
 @end
 
@@ -220,8 +219,7 @@ static const CGFloat kBadgeFontSize = 14.0;
         make.size.equalTo(kButtonSide);
         make.bottom.equalTo(self.microphoneButton.top).with.offset(-k3ButtonGap);
 
-        self.videoCenterXConstraint = make.centerX.equalTo(self.controlsContainerView);
-        self.videoRightConstraint = make.right.equalTo(self.controlsContainerView);
+        self.videoHorizontalConstraint = make.centerX.equalTo(self.controlsContainerView);
     }];
 
     [self.resumeButton makeConstraints:^(MASConstraintMaker *make) {
@@ -332,15 +330,23 @@ static const CGFloat kBadgeFontSize = 14.0;
 - (void)showResumeButton
 {
     self.resumeButton.hidden = NO;
-    [self.videoCenterXConstraint deactivate];
-    [self.videoRightConstraint activate];
+
+    [self.videoHorizontalConstraint uninstall];
+
+    [self.videoButton updateConstraints:^(MASConstraintMaker *make) {
+        self.videoHorizontalConstraint = make.right.equalTo(self.controlsContainerView);
+    }];
 }
 
 - (void)hideResumeButton
 {
     self.resumeButton.hidden = YES;
-    [self.videoCenterXConstraint activate];
-    [self.videoRightConstraint deactivate];
+
+    [self.videoHorizontalConstraint uninstall];
+
+    [self.videoButton updateConstraints:^(MASConstraintMaker *make) {
+        self.videoHorizontalConstraint = make.centerX.equalTo(self.controlsContainerView);
+    }];
 }
 
 - (void)hideIncomingCallView

--- a/Antidote/ActiveCallViewController.m
+++ b/Antidote/ActiveCallViewController.m
@@ -48,8 +48,6 @@ static const CGFloat kBadgeFontSize = 14.0;
 
 @property (strong, nonatomic) NSTimer *tableViewRefreshTimer;
 
-@property (strong, nonatomic) MASConstraint *videoHorizontalConstraint;
-
 @end
 
 @implementation ActiveCallViewController
@@ -69,7 +67,7 @@ static const CGFloat kBadgeFontSize = 14.0;
 
     [self installConstraints];
 
-    [self hideResumeButton];
+    self.resumeButtonHidden = YES;
 
     [self reloadPausedCalls];
 }
@@ -249,14 +247,13 @@ static const CGFloat kBadgeFontSize = 14.0;
     [self setupIncomingCallViewForFriend:nickname];
 }
 
-- (void)showResumeButton
+- (void)setResumeButtonHidden:(BOOL)resumeButtonHidden
 {
-    [self.callControlsView showResumeButton];
-}
+    if (self.callControlsView.resumeButtonHidden == resumeButtonHidden) {
+        return;
+    }
 
-- (void)hideResumeButton
-{
-    [self.callControlsView hideResumeButton];
+    self.callControlsView.resumeButtonHidden = resumeButtonHidden;
 }
 
 - (void)hideIncomingCallView

--- a/Antidote/CallControlsView.h
+++ b/Antidote/CallControlsView.h
@@ -1,0 +1,45 @@
+//
+//  CallControlsView.h
+//  Antidote
+//
+//  Created by Chuong Vu on 7/27/15.
+//  Copyright (c) 2015 dvor. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@class CallControlsView;
+
+@protocol CallControlsViewDelegate <NSObject>
+
+- (void)callControlsMicButtonPressed:(CallControlsView *)callsControlView;
+- (void)callControlsSpeakerButtonPressed:(CallControlsView *)callsControlView;
+- (void)callControlsResumeButtonPressed:(CallControlsView *)callsControlView;
+
+@end
+
+@interface CallControlsView : UIView
+
+@property (weak, nonatomic) id<CallControlsViewDelegate> delegate;
+
+/**
+ * Set the microphone to be selected or not selected
+ */
+@property (assign, nonatomic) BOOL micSelected;
+
+/**
+ * Set the speaker to be selected or not selected
+ */
+@property (assign, nonatomic) BOOL speakerSelected;
+
+/**
+ * Show the resume button so the user can resume a paused call.
+ */
+- (void)showResumeButton;
+
+/**
+ * Hide the resume button.
+ */
+- (void)hideResumeButton;
+
+@end

--- a/Antidote/CallControlsView.h
+++ b/Antidote/CallControlsView.h
@@ -33,13 +33,8 @@
 @property (assign, nonatomic) BOOL speakerSelected;
 
 /**
- * Show the resume button so the user can resume a paused call.
+ * Set the resume button to be hidden or not.
  */
-- (void)showResumeButton;
-
-/**
- * Hide the resume button.
- */
-- (void)hideResumeButton;
+@property (assign, nonatomic) BOOL resumeButtonHidden;
 
 @end

--- a/Antidote/CallControlsView.m
+++ b/Antidote/CallControlsView.m
@@ -44,8 +44,6 @@ static const CGFloat k3ButtonGap = 15.0;
 
     [self installConstraints];
 
-    [self hideResumeButton];
-
     return self;
 }
 
@@ -75,6 +73,7 @@ static const CGFloat k3ButtonGap = 15.0;
     self.resumeButton = [self createButtonWithImageName:@"call-pause" action:@selector(resumeButtonPressed)];
     self.resumeButton.tintColor = [[AppContext sharedContext].appearance callRedColor];
     self.resumeButton.layer.borderColor = [[AppContext sharedContext].appearance callRedColor].CGColor;
+    self.resumeButton.hidden = YES;
 
     [self addSubview:self.resumeButton];
 }
@@ -137,14 +136,7 @@ static const CGFloat k3ButtonGap = 15.0;
 {
     self.microphoneButton.selected = micSelected;
 
-    if (micSelected) {
-        self.microphoneButton.backgroundColor = [UIColor whiteColor];
-        self.microphoneButton.tintColor = [UIColor grayColor];
-    }
-    else {
-        self.microphoneButton.backgroundColor = [UIColor clearColor];
-        self.microphoneButton.tintColor = [UIColor whiteColor];
-    }
+    [self setButton:self.microphoneButton selected:micSelected];
 }
 
 - (BOOL)micSelected
@@ -156,14 +148,7 @@ static const CGFloat k3ButtonGap = 15.0;
 {
     self.speakerButton.selected = speakerSelected;
 
-    if (speakerSelected) {
-        self.speakerButton.backgroundColor = [UIColor whiteColor];
-        self.speakerButton.tintColor = [UIColor grayColor];
-    }
-    else {
-        self.speakerButton.backgroundColor = [UIColor clearColor];
-        self.speakerButton.tintColor = [UIColor whiteColor];
-    }
+    [self setButton:self.speakerButton selected:speakerSelected];
 }
 
 - (BOOL)speakerSelected
@@ -171,26 +156,29 @@ static const CGFloat k3ButtonGap = 15.0;
     return self.speakerButton.selected;
 }
 
-- (void)showResumeButton
+- (void)setResumeButtonHidden:(BOOL)resumeButtonHidden
 {
-    self.resumeButton.hidden = NO;
+    self.resumeButton.hidden = resumeButtonHidden;
 
     [self.videoHorizontalConstraint uninstall];
 
-    [self.videoButton updateConstraints:^(MASConstraintMaker *make) {
-        self.videoHorizontalConstraint = make.right.equalTo(self);
-    }];
+    if (resumeButtonHidden) {
+
+        [self.videoButton updateConstraints:^(MASConstraintMaker *make) {
+            self.videoHorizontalConstraint = make.centerX.equalTo(self);
+        }];
+    }
+    else {
+
+        [self.videoButton updateConstraints:^(MASConstraintMaker *make) {
+            self.videoHorizontalConstraint = make.right.equalTo(self);
+        }];
+    }
 }
 
-- (void)hideResumeButton
+- (BOOL)resumeButtonHidden
 {
-    self.resumeButton.hidden = YES;
-
-    [self.videoHorizontalConstraint uninstall];
-
-    [self.videoButton updateConstraints:^(MASConstraintMaker *make) {
-        self.videoHorizontalConstraint = make.centerX.equalTo(self);
-    }];
+    return self.resumeButton.hidden;
 }
 
 #pragma mark - Private
@@ -212,6 +200,18 @@ static const CGFloat k3ButtonGap = 15.0;
     [button addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
 
     return button;
+}
+
+- (void)setButton:(UIButton *)button selected:(BOOL)selected
+{
+    if (selected) {
+        button.backgroundColor = [UIColor whiteColor];
+        button.tintColor = [UIColor grayColor];
+    }
+    else {
+        button.backgroundColor = [UIColor clearColor];
+        button.tintColor = [UIColor whiteColor];
+    }
 }
 
 @end

--- a/Antidote/CallControlsView.m
+++ b/Antidote/CallControlsView.m
@@ -1,0 +1,217 @@
+//
+//  CallControlsView.m
+//  Antidote
+//
+//  Created by Chuong Vu on 7/27/15.
+//  Copyright (c) 2015 dvor. All rights reserved.
+//
+
+#import "CallControlsView.h"
+#import "AppearanceManager.h"
+#import "Masonry.h"
+
+static const CGFloat kButtonBorderWidth = 1.5f;
+static const CGFloat kButtonSide = 75.0;
+static const CGFloat k3ButtonGap = 15.0;
+
+@interface CallControlsView ()
+
+@property (strong, nonatomic) UIButton *videoButton;
+@property (strong, nonatomic) UIButton *microphoneButton;
+@property (strong, nonatomic) UIButton *speakerButton;
+@property (strong, nonatomic) UIButton *resumeButton;
+
+@property (strong, nonatomic) MASConstraint *videoHorizontalConstraint;
+
+@end
+
+@implementation CallControlsView
+
+- (instancetype)init
+{
+    self = [super init];
+
+    if (! self) {
+        return nil;
+    }
+
+    self.backgroundColor = [UIColor clearColor];
+
+    [self createVideoButton];
+    [self createMicrophoneButton];
+    [self createSpeakerButton];
+    [self createResumeButton];
+
+    [self installConstraints];
+
+    [self hideResumeButton];
+
+    return self;
+}
+
+- (void)createVideoButton
+{
+    self.videoButton = [self createButtonWithImageName:@"call-video" action:nil];
+
+    [self addSubview:self.videoButton];
+}
+
+- (void)createMicrophoneButton
+{
+    self.microphoneButton = [self createButtonWithImageName:@"call-microphone-disable" action:@selector(micButtonPressed)];
+
+    [self addSubview:self.microphoneButton];
+}
+
+- (void)createSpeakerButton
+{
+    self.speakerButton = [self createButtonWithImageName:@"call-audio-enable" action:@selector(speakerButtonPressed)];
+
+    [self addSubview:self.speakerButton];
+}
+
+- (void)createResumeButton
+{
+    self.resumeButton = [self createButtonWithImageName:@"call-pause" action:@selector(resumeButtonPressed)];
+    self.resumeButton.tintColor = [[AppContext sharedContext].appearance callRedColor];
+    self.resumeButton.layer.borderColor = [[AppContext sharedContext].appearance callRedColor].CGColor;
+
+    [self addSubview:self.resumeButton];
+}
+
+- (void)installConstraints
+{
+    [self.videoButton makeConstraints:^(MASConstraintMaker *make) {
+        make.top.equalTo(self);
+        make.size.equalTo(kButtonSide);
+        make.bottom.equalTo(self.microphoneButton.top).with.offset(-k3ButtonGap);
+
+        self.videoHorizontalConstraint = make.centerX.equalTo(self);
+    }];
+
+    [self.resumeButton makeConstraints:^(MASConstraintMaker *make) {
+        make.right.equalTo(self.videoButton.left).with.offset(-k3ButtonGap);
+        make.centerY.equalTo(self.videoButton);
+        make.size.equalTo(kButtonSide);
+    }];
+
+    [self.microphoneButton makeConstraints:^(MASConstraintMaker *make) {
+        make.left.equalTo(self);
+        make.right.equalTo(self.speakerButton.left).with.offset(-k3ButtonGap);
+        make.size.equalTo(kButtonSide);
+        make.top.equalTo(self.videoButton.bottom).with.offset(k3ButtonGap);
+    }];
+
+    [self.speakerButton makeConstraints:^(MASConstraintMaker *make) {
+        make.right.equalTo(self);
+        make.size.equalTo(kButtonSide);
+        make.centerY.equalTo(self.microphoneButton);
+    }];
+
+    [self makeConstraints:^(MASConstraintMaker *make) {
+        make.top.equalTo(self.videoButton);
+        make.bottom.equalTo(self.microphoneButton);
+    }];
+}
+
+#pragma mark - Touch actions
+
+- (void)micButtonPressed
+{
+    [self.delegate callControlsMicButtonPressed:self];
+}
+
+- (void)speakerButtonPressed
+{
+    [self.delegate callControlsSpeakerButtonPressed:self];
+}
+
+- (void)resumeButtonPressed
+{
+    [self.delegate callControlsResumeButtonPressed:self];
+}
+
+#pragma makr - Public
+
+- (void)setMicSelected:(BOOL)micSelected
+{
+    self.microphoneButton.selected = micSelected;
+
+    if (micSelected) {
+        self.microphoneButton.backgroundColor = [UIColor whiteColor];
+        self.microphoneButton.tintColor = [UIColor grayColor];
+    }
+    else {
+        self.microphoneButton.backgroundColor = [UIColor clearColor];
+        self.microphoneButton.tintColor = [UIColor whiteColor];
+    }
+}
+
+- (BOOL)micSelected
+{
+    return self.microphoneButton.selected;
+}
+
+- (void)setSpeakerSelected:(BOOL)speakerSelected
+{
+    self.speakerButton.selected = speakerSelected;
+
+    if (speakerSelected) {
+        self.speakerButton.backgroundColor = [UIColor whiteColor];
+        self.speakerButton.tintColor = [UIColor grayColor];
+    }
+    else {
+        self.speakerButton.backgroundColor = [UIColor clearColor];
+        self.speakerButton.tintColor = [UIColor whiteColor];
+    }
+}
+
+- (BOOL)speakerSelected
+{
+    return self.speakerButton.selected;
+}
+
+- (void)showResumeButton
+{
+    self.resumeButton.hidden = NO;
+
+    [self.videoHorizontalConstraint uninstall];
+
+    [self.videoButton updateConstraints:^(MASConstraintMaker *make) {
+        self.videoHorizontalConstraint = make.right.equalTo(self);
+    }];
+}
+
+- (void)hideResumeButton
+{
+    self.resumeButton.hidden = YES;
+
+    [self.videoHorizontalConstraint uninstall];
+
+    [self.videoButton updateConstraints:^(MASConstraintMaker *make) {
+        self.videoHorizontalConstraint = make.centerX.equalTo(self);
+    }];
+}
+
+#pragma mark - Private
+
+- (UIButton *)createButtonWithImageName:(NSString *)imageName action:(SEL)action
+{
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
+    UIImage *image = [UIImage imageNamed:imageName];
+    [button setImage:image forState:UIControlStateNormal];
+
+    button.tintColor = [UIColor whiteColor];
+
+    button.contentMode = UIViewContentModeScaleAspectFill;
+    button.layer.cornerRadius = kButtonSide / 2.0f;
+    button.layer.masksToBounds = YES;
+    button.layer.borderColor = [UIColor whiteColor].CGColor;
+    button.layer.borderWidth = kButtonBorderWidth;
+
+    [button addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
+
+    return button;
+}
+
+@end

--- a/Antidote/CallsManager.m
+++ b/Antidote/CallsManager.m
@@ -268,9 +268,8 @@
     if (! [self.manager sendCallControl:OCTToxAVCallControlResume toCall:call error:&error]) {
         AALogWarn(@"%@", error);
     }
-    ;
 
-    [controller hideResumeButton];
+    controller.resumeButtonHidden = YES;
 }
 
 - (void)activeCallDeclineIncomingCallButtonPressed:(ActiveCallViewController *)controller
@@ -471,10 +470,7 @@
 
         ActiveCallViewController *activeVC = (ActiveCallViewController *)self.currentCallViewController;
 
-        if (call.pausedStatus == OCTCallPausedStatusByUser) {
-            [activeVC showResumeButton];
-        }
-
+        activeVC.resumeButtonHidden = ! (call.pausedStatus == OCTCallPausedStatusByUser);
         OCTFriend *friend = [call.chat.friends firstObject];
         self.currentCallViewController.nickname = friend.nickname;
         self.currentCall = [RBQSafeRealmObject safeObjectFromObject:call];


### PR DESCRIPTION
Figured that `ActiveCallsViewController` was getting a little too big. Moved the the call controls to a separate class. Also resolved this issue https://github.com/Antidote-for-Tox/Antidote/issues/87