### PR TITLE
Bug fix #106 preview layer removal slowness

### DIFF
--- a/Antidote/ActiveCallViewController.h
+++ b/Antidote/ActiveCallViewController.h
@@ -83,9 +83,9 @@
  * Since it takes a while for the preview layer to be loaded,
  * it is best to set this to YES to indicate that one is loaded and in progress
  * or that it is already present.
- * Set to YES if the preview view is being shown, otherwise NO.
+ * Set to YES before providing a preview layer.
  */
-@property (nonatomic, assign) BOOL previewViewIsShown;
+@property (nonatomic, assign) BOOL previewViewLoaded;
 
 /**
  * Create an incoming call view for friend

--- a/Antidote/ActiveCallViewController.m
+++ b/Antidote/ActiveCallViewController.m
@@ -358,7 +358,7 @@ static const CGFloat kAvatarDiameter = 180.0;
 
 - (void)providePreviewLayer:(CALayer *)layer
 {
-    self.videoContainerView.previewLayer = layer;
+    [self.videoContainerView providePreviewLayer:layer];
 
     [self switchToVideoViewIfNeeded];
 }
@@ -442,7 +442,7 @@ static const CGFloat kAvatarDiameter = 180.0;
 
 - (void)switchToVideoViewIfNeeded
 {
-    BOOL videoVisible = (self.videoContainerView.videoView || self.previewViewIsShown);
+    BOOL videoVisible = (self.videoContainerView.videoView || ! self.videoContainerView.previewViewHidden);
 
     self.videoContainerView.hidden = ! videoVisible;
     self.expandedControlsView.hidden = videoVisible;

--- a/Antidote/CallsManager.m
+++ b/Antidote/CallsManager.m
@@ -224,8 +224,8 @@
         }
 
 
-        if (call.videoIsEnabled && ! activeVC.previewViewIsShown) {
-            activeVC.previewViewIsShown = YES;
+        if (call.videoIsEnabled && ! activeVC.previewViewLoaded) {
+            activeVC.previewViewLoaded = YES;
             __weak ActiveCallViewController *weakVC = activeVC;
             [self.manager getVideoCallPreview:^(CALayer *layer) {
                 ActiveCallViewController *strongVC = weakVC;
@@ -242,8 +242,8 @@
             [activeVC provideVideoView:nil];
         }
 
-        if (! call.videoIsEnabled && activeVC.previewViewIsShown) {
-            activeVC.previewViewIsShown = NO;
+        if (! call.videoIsEnabled && activeVC.previewViewLoaded) {
+            activeVC.previewViewLoaded = NO;
             [activeVC providePreviewLayer:nil];
             activeVC.videoButtonSelected = NO;
         }

--- a/Antidote/VideoAndPreviewView.h
+++ b/Antidote/VideoAndPreviewView.h
@@ -24,9 +24,15 @@
 @property (strong, nonatomic) UIView *videoView;
 
 /**
- * The preview layer for the preview video.
- * Setting this to nil will hide the preview view.
+ * YES if the preview view is currently hidden, otherwise NO.
  */
-@property (strong, nonatomic) CALayer *previewLayer;
+@property (nonatomic, assign, readonly) BOOL previewViewHidden;
+
+/**
+ * Provide a preview layer to be added.
+ * @param previewLayer Layer to add for preview video.
+ * If previewLayer is nil, the preview view will be hidden.
+ */
+- (void)providePreviewLayer:(CALayer *)previewLayer;
 
 @end

--- a/Antidote/VideoAndPreviewView.m
+++ b/Antidote/VideoAndPreviewView.m
@@ -11,9 +11,11 @@
 
 static const CGFloat kPreviewViewWidth = 75.0;
 static const CGFloat kPreviewViewHeight = 100.0;
+
 @interface VideoAndPreviewView ()
 
 @property (strong, nonatomic) UIView *previewView;
+@property (weak, nonatomic) CALayer *previewLayer;
 
 @end
 
@@ -93,25 +95,26 @@ static const CGFloat kPreviewViewHeight = 100.0;
     }];
 }
 
-- (void)setPreviewLayer:(CALayer *)previewLayer
+- (BOOL)previewViewHidden
 {
-    if (previewLayer == _previewLayer) {
-        return;
-    }
+    return self.previewView.hidden;
+}
 
-    if (_previewLayer) {
-        [_previewLayer removeFromSuperlayer];
-    }
-
-    _previewLayer = previewLayer;
-
-    if (! _previewLayer) {
+- (void)providePreviewLayer:(CALayer *)previewLayer
+{
+    if (! previewLayer) {
         self.previewView.hidden = YES;
         return;
     }
 
-    [self.previewView.layer addSublayer:self.previewLayer];
     self.previewView.hidden = NO;
+
+    if (previewLayer == self.previewLayer) {
+        return;
+    }
+
+    [self.previewView.layer addSublayer:previewLayer];
+    self.previewLayer = previewLayer;
     [self adjustPreviewLayer];
 }
 


### PR DESCRIPTION
Rather than remove the layer after video engine stops running, the
`VideoViewAndPreview` will hold onto it until the user exits out of video mode.

https://github.com/Antidote-for-Tox/Antidote/issues/106