### PR TITLE
Disable notifications for message calls

### DIFF
--- a/Antidote/ToxListener.m
+++ b/Antidote/ToxListener.m
@@ -191,6 +191,10 @@ NSString *const kToxListenerGroupIdentifierFriendRequest = @"kToxListenerGroupId
     AppDelegate *delegate = (AppDelegate *)[UIApplication sharedApplication].delegate;
     UIViewController *visibleVC = [delegate visibleViewController];
 
+    if (message.messageCall) {
+        return NO;
+    }
+
     if (! [visibleVC isKindOfClass:[ChatViewController class]]) {
         return YES;
     }


### PR DESCRIPTION
For issue https://github.com/Antidote-for-Tox/Antidote/issues/125

I disabled it in all cases since I don't see any reason to show it if we are already updating the UI anyways.