### PR TITLE
Fix tests not compiling

### DIFF
--- a/AntidoteTests/ChatIncomingTextCellSnapshotTest.swift
+++ b/AntidoteTests/ChatIncomingTextCellSnapshotTest.swift
@@ -16,7 +16,7 @@ class ChatIncomingTextCellSnapshotTest: CellSnapshotTest {
     }
 
     func testSmallMessage() {
-        let model = ChatIncomingTextCellModel()
+        let model = ChatBaseTextCellModel()
         model.message = "Hi"
 
         let cell = ChatIncomingTextCell()
@@ -27,7 +27,7 @@ class ChatIncomingTextCellSnapshotTest: CellSnapshotTest {
     }
 
     func testMediumMessage() {
-        let model = ChatIncomingTextCellModel()
+        let model = ChatBaseTextCellModel()
         model.message = "Some nice medium message"
 
         let cell = ChatIncomingTextCell()
@@ -38,7 +38,7 @@ class ChatIncomingTextCellSnapshotTest: CellSnapshotTest {
     }
 
     func testHugeMessage() {
-        let model = ChatIncomingTextCellModel()
+        let model = ChatBaseTextCellModel()
         model.message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. "
 
         let cell = ChatIncomingTextCell()

--- a/AntidoteTests/ChatOutgoingTextCellSnapshotTest.swift
+++ b/AntidoteTests/ChatOutgoingTextCellSnapshotTest.swift
@@ -16,7 +16,7 @@ class ChatOutgoingTextCellSnapshotTest: CellSnapshotTest {
     }
 
     func testSmallMessage() {
-        let model = ChatOutgoingTextCellModel()
+        let model = ChatBaseTextCellModel()
         model.message = "Hi"
 
         let cell = ChatOutgoingTextCell()
@@ -27,7 +27,7 @@ class ChatOutgoingTextCellSnapshotTest: CellSnapshotTest {
     }
 
     func testMediumMessage() {
-        let model = ChatOutgoingTextCellModel()
+        let model = ChatBaseTextCellModel()
         model.message = "Some nice medium message"
 
         let cell = ChatOutgoingTextCell()
@@ -38,7 +38,7 @@ class ChatOutgoingTextCellSnapshotTest: CellSnapshotTest {
     }
 
     func testHugeMessage() {
-        let model = ChatOutgoingTextCellModel()
+        let model = ChatBaseTextCellModel()
         model.message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. "
 
         let cell = ChatOutgoingTextCell()


### PR DESCRIPTION
ChatIncomingTextCellSnapshotTest and ChatOutgoingTextCellSnapshotTest needed to be updated to use ChatBaseTextCellModel, as the models they were using no longer existed.