### PR TITLE
Standardize ChatListCell and FriendListCell UI

### DIFF
--- a/Antidote/ChatListCell.swift
+++ b/Antidote/ChatListCell.swift
@@ -19,7 +19,7 @@ class ChatListCell: BaseCell {
         static let MessageLabelHeight = 22.0
 
         static let NicknameToDateMinOffset = 5.0
-        static let DateToArrowOffset = 5.0
+        static let DateToArrowOffset = -5.0
 
         static let RightOffset = -7.0
         static let VerticalOffset = 3.0
@@ -99,7 +99,7 @@ class ChatListCell: BaseCell {
 
         messageLabel.snp_makeConstraints {
             $0.leading.equalTo(nicknameLabel)
-            $0.trailing.equalTo(contentView).offset(Constants.RightOffset)
+            $0.trailing.equalTo(dateLabel.snp_trailing)
             $0.top.equalTo(nicknameLabel.snp_bottom)
             $0.bottom.equalTo(contentView).offset(-Constants.VerticalOffset)
             $0.height.equalTo(Constants.MessageLabelHeight)
@@ -109,11 +109,12 @@ class ChatListCell: BaseCell {
             $0.leading.greaterThanOrEqualTo(nicknameLabel.snp_trailing).offset(Constants.NicknameToDateMinOffset)
             $0.top.equalTo(nicknameLabel)
             $0.height.equalTo(nicknameLabel)
+            $0.trailing.equalTo(arrowImageView.snp_leading).offset(Constants.DateToArrowOffset)
         }
 
         arrowImageView.snp_makeConstraints {
-            $0.centerY.equalTo(dateLabel)
-            $0.leading.greaterThanOrEqualTo(dateLabel.snp_trailing).offset(Constants.DateToArrowOffset)
+            $0.centerY.equalTo(contentView)
+            $0.leading.greaterThanOrEqualTo(nicknameLabel.snp_trailing)
             $0.trailing.equalTo(contentView).offset(Constants.RightOffset)
         }
     }

--- a/Antidote/FriendListCell.swift
+++ b/Antidote/FriendListCell.swift
@@ -11,14 +11,15 @@ import SnapKit
 
 class FriendListCell: BaseCell {
     struct Constants {
-        static let AvatarSize = 30.0
+        static let AvatarSize = 40.0
         static let AvatarLeftOffset = 10.0
         static let AvatarRightOffset = 16.0
 
         static let TopLabelHeight = 22.0
-        static let MinimumBottomLabelHeight = 15.0
+        static let MinimumBottomLabelHeight = 22.0
 
         static let VerticalOffset = 3.0
+        static let RightOffset = -7.0
     }
 
     private var avatarView: ImageViewWithStatus!
@@ -94,7 +95,7 @@ class FriendListCell: BaseCell {
         arrowImageView.snp_makeConstraints {
             $0.centerY.equalTo(contentView)
             $0.leading.greaterThanOrEqualTo(topLabel.snp_trailing)
-            $0.trailing.equalTo(contentView)
+            $0.trailing.equalTo(contentView).offset(Constants.RightOffset)
         }
     }
 }


### PR DESCRIPTION
I recently noticed the cells for the Contacts and Chats lists were sized different, making the UI seem off when switching between the two.  This change standardizes the UI elements in both ChatListCell and FriendListCell to have the same size and appearance.

In Particular:

- Avatars are now the same size
- Bottom labels are now the same size
- The right arrow is in the same position
- Chat message doesn't extend past the end of the date label