### PR TITLE
Fix markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 See [FAQ](FAQ/en.md).
 
-##Usage
+## Usage
 
 #### TestFlight beta testing
 


### PR DESCRIPTION
[GitHub has changed their Markdown parser](https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown), which broke several previously working things, one of which is `#Heading`. It's now required to have a space after `#`, i.e. `# Heading` is the correct heading.